### PR TITLE
Fix bug in learning experiences logging

### DIFF
--- a/actions/base_dqn.py
+++ b/actions/base_dqn.py
@@ -210,6 +210,18 @@ class BaseDQNModule:
                     self.db.batch_log_learning_experiences(self.pending_experiences)
                 self.pending_experiences = []
 
+        # Log individual experience
+        if all(x is not None for x in [step_number, agent_id, module_type]):
+            self._log_experience(
+                step_number=step_number,
+                agent_id=agent_id,
+                module_type=module_type,
+                state=state,
+                action=action,
+                reward=reward,
+                next_state=next_state,
+            )
+
     def train(
         self,
         batch: list,

--- a/environment.py
+++ b/environment.py
@@ -104,9 +104,8 @@ class Environment:
                 np.random.random(len(self.resources)) < self.config.resource_regen_rate
             )
             for resource, should_regen in zip(self.resources, regen_mask):
-                if should_regen and (
-                    self.max_resource is None or resource.amount < self.max_resource
-                ):
+                if (should_regen and 
+                    (self.max_resource is None or resource.amount < self.max_resource)):
                     resource.amount = min(
                         resource.amount + self.config.resource_regen_amount,
                         self.max_resource or float("inf"),
@@ -128,6 +127,18 @@ class Environment:
                 metrics=metrics,
                 environment=self,
             )
+
+            # Call cleanup method of each agent's DQN modules to log learning experiences
+            for agent in self.agents:
+                for module in [
+                    agent.move_module,
+                    agent.attack_module,
+                    agent.share_module,
+                    agent.gather_module,
+                    agent.reproduce_module,
+                ]:
+                    if hasattr(module, "cleanup"):
+                        module.cleanup()
 
         # Execute all updates in a single transaction
         self.db._execute_in_transaction(_process_updates)


### PR DESCRIPTION
Related to #49

Fix the issue of `LearningExperiences` table not being populated with data.

* **actions/base_dqn.py**
  - Call `log_learning_experience` within the `store_experience` method to log individual experiences.
  - Ensure `cleanup` method calls `batch_log_learning_experiences` to log pending experiences.

* **environment.py**
  - Call `cleanup` method of each agent's DQN modules within the `update` method to log learning experiences.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Dooders/Experiments/pull/50?shareId=d10a431c-0b2e-43fb-a8c1-3e27f2f15226).